### PR TITLE
fix: allow Param nodes in subscript expr

### DIFF
--- a/ast/utils.go
+++ b/ast/utils.go
@@ -127,6 +127,8 @@ func IsSubscriptExpression(e Expression) bool {
 			default:
 				return false
 			}
+		case *Param:
+			return true
 		default:
 			return false
 		}


### PR DESCRIPTION
Fixes issue when using mode `WithParamNodes`, a query like:
```
*[_type == "blog"] | order(publishedAt desc) [0...$var]
```
Fails to be parsed with error "parse error at positions 45..55: subscript ranges must have integer endpoints"

Ref CLDX-1112