### PR TITLE
Fix Walk() to handle Tuple structs

### DIFF
--- a/ast/json.go
+++ b/ast/json.go
@@ -34,13 +34,13 @@ func (e *Constraint) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalJSON marshals an AST node to JSON.
-func (expr *ArrayTraversal) MarshalJSON() ([]byte, error) {
+func (e *ArrayTraversal) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Node string `json:"node,omitempty"`
 		Pos  int    `json:"pos"`
 	}{
 		"arrayTraversal",
-		expr.Pos.Start,
+		e.Pos.Start,
 	})
 }
 

--- a/ast/transform.go
+++ b/ast/transform.go
@@ -69,9 +69,7 @@ func (e *Group) Transform(f TransformFunc) Expression {
 
 func (e *Tuple) Transform(f TransformFunc) Expression {
 	out := *e
-	for idx, expr := range e.Members {
-		e.Members[idx] = Transform(expr, f)
-	}
+	out.Members = transformExprs(e.Members, f)
 	return f(&out)
 }
 
@@ -157,4 +155,15 @@ func (e *FunctionPipe) Transform(f TransformFunc) Expression {
 	out.LHS = Transform(e.LHS, f)
 	out.Func = Transform(e.Func, f).(*FunctionCall)
 	return f(&out)
+}
+
+func transformExprs(in []Expression, f TransformFunc) []Expression {
+	if len(in) == 0 {
+		return nil
+	}
+	result := make([]Expression, len(in))
+	for i, e := range in {
+		result[i] = Transform(e, f)
+	}
+	return result
 }

--- a/ast/transform.go
+++ b/ast/transform.go
@@ -93,32 +93,20 @@ func (e *PostfixOperator) Transform(f TransformFunc) Expression {
 }
 
 func (e *Object) Transform(f TransformFunc) Expression {
-	newExprs := make([]Expression, len(e.Expressions))
-	for i, x := range e.Expressions {
-		newExprs[i] = Transform(x, f)
-	}
 	out := *e
-	out.Expressions = newExprs
+	out.Expressions = transformExprs(e.Expressions, f)
 	return f(&out)
 }
 
 func (e *Array) Transform(f TransformFunc) Expression {
-	newExprs := make([]Expression, len(e.Expressions))
-	for i, x := range e.Expressions {
-		newExprs[i] = Transform(x, f)
-	}
 	out := *e
-	out.Expressions = newExprs
+	out.Expressions = transformExprs(e.Expressions, f)
 	return f(&out)
 }
 
 func (e *FunctionCall) Transform(f TransformFunc) Expression {
-	newArgs := make([]Expression, len(e.Arguments))
-	for i, x := range e.Arguments {
-		newArgs[i] = Transform(x, f)
-	}
 	out := *e
-	out.Arguments = newArgs
+	out.Arguments = transformExprs(e.Arguments, f)
 	return f(&out)
 }
 

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -65,6 +65,8 @@ func Walk(expr Expression, visitor func(Expression) bool) bool {
 		return walkExprs(visitor, e.LHS, e.Idx)
 	case *Projection:
 		return walkExprs(visitor, e.LHS, e.Object)
+	case *Tuple:
+		return walkExprs(visitor, e.Members...)
 	}
 
 	panic(fmt.Sprintf("Unexpected AST expression of type %T: %[1]v", expr))


### PR DESCRIPTION
Fixes `Walk()` to handle `Tuple` structs, plus some cleanup.