### PR TITLE
feat(parservX): allow multiple keywords for function definition

### DIFF
--- a/parser/internal/parservX/parser.go
+++ b/parser/internal/parservX/parser.go
@@ -842,7 +842,7 @@ func (p *parser) parseFunctionDefinitions() error {
 
 	for {
 		tok, lit, _ := p.scanIgnoreWhitespace()
-		if tok == ast.Name && lit == "def" {
+		if tok == ast.Name && p.isFunctionDefinitionKeyword(lit) {
 			function, err := p.parseFunctionDefinition()
 			if err != nil {
 				return err
@@ -854,6 +854,15 @@ func (p *parser) parseFunctionDefinitions() error {
 		}
 	}
 	return nil
+}
+
+func (p *parser) isFunctionDefinitionKeyword(s string) bool {
+	switch s {
+	case "def", "fn", "func", "function", "let", "const":
+		return true
+	default:
+		return false
+	}
 }
 
 /*

--- a/parser/internal/parservX/parser_test.go
+++ b/parser/internal/parservX/parser_test.go
@@ -113,7 +113,7 @@ func transformToLegacyAST(expr ast.Expression) ast.Expression {
 
 func TestErrors(t *testing.T) {
 	assertParseFailure(t, "(person", "expected ')' following parenthesized expression", 0, 8)
-	assertParseFailure(t, "fn(person", "expected ')' following function arguments", 2, 10)
+	assertParseFailure(t, "count(person", "expected ')' following function arguments", 5, 13)
 	assertParseFailure(t, "[1,2", "expected ']' following array body", 0, 5)
 	assertParseFailure(t, "{a", "expected '}' following object body", 0, 3)
 	assertParseFailure(t, "[1,2,3]....", "unable to parse entire expression", 7, 7)


### PR DESCRIPTION
We'd like to support multiple keywords for defining a function and let people decide which one is the best.