### PR TITLE
fix(ast): equality for Object, Array, Tuple, and FuncCall

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -369,11 +369,9 @@ func (e *Projection) Equal(b Expression) bool {
 
 func (e *Object) Equal(b Expression) bool {
 	if b, ok := b.(*Object); ok && len(e.Expressions) == len(b.Expressions) {
-		for _, ae := range e.Expressions {
-			for _, be := range b.Expressions {
-				if !ae.Equal(be) {
-					return false
-				}
+		for idx, ae := range e.Expressions {
+			if !ae.Equal(b.Expressions[idx]) {
+				return false
 			}
 		}
 		return true
@@ -383,11 +381,9 @@ func (e *Object) Equal(b Expression) bool {
 
 func (e *Array) Equal(b Expression) bool {
 	if b, ok := b.(*Array); ok && len(e.Expressions) == len(b.Expressions) {
-		for _, ae := range e.Expressions {
-			for _, be := range b.Expressions {
-				if !ae.Equal(be) {
-					return false
-				}
+		for idx, ae := range e.Expressions {
+			if !ae.Equal(b.Expressions[idx]) {
+				return false
 			}
 		}
 		return true
@@ -397,11 +393,9 @@ func (e *Array) Equal(b Expression) bool {
 
 func (e *FunctionCall) Equal(b Expression) bool {
 	if b, ok := b.(*FunctionCall); ok && e.Namespace == b.Namespace && e.Name == b.Name && len(e.Arguments) == len(b.Arguments) {
-		for _, ae := range e.Arguments {
-			for _, be := range b.Arguments {
-				if !ae.Equal(be) {
-					return false
-				}
+		for idx, ae := range e.Arguments {
+			if !ae.Equal(b.Arguments[idx]) {
+				return false
 			}
 		}
 		return true
@@ -479,11 +473,9 @@ func (e *Subscript) Equal(b Expression) bool {
 
 func (e *Tuple) Equal(b Expression) bool {
 	if b, ok := b.(*Tuple); ok && len(e.Members) == len(b.Members) {
-		for _, ae := range e.Members {
-			for _, be := range b.Members {
-				if !ae.Equal(be) {
-					return false
-				}
+		for idx, ae := range e.Members {
+			if !ae.Equal(b.Members[idx]) {
+				return false
 			}
 		}
 		return true

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -1,0 +1,90 @@
+package ast_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sanity-io/go-groq/ast"
+)
+
+func TestAST_ObjectEquality(t *testing.T) {
+	a := &ast.Object{
+		Expressions: []ast.Expression{
+			&ast.Attribute{Name: "a"},
+			&ast.Attribute{Name: "b"},
+		},
+	}
+
+	b := &ast.Object{
+		Expressions: []ast.Expression{
+			&ast.Attribute{Name: "a"},
+			&ast.Attribute{Name: "b"},
+		},
+	}
+
+	c := &ast.Object{
+		Expressions: []ast.Expression{
+			&ast.Attribute{Name: "b"},
+			&ast.Attribute{Name: "a"},
+		},
+	}
+
+	assert.True(t, a.Equal(a)) // should be equal to itself
+	assert.True(t, a.Equal(b)) // should be equal to another identical object
+	assert.False(t, a.Equal(c))
+}
+
+func TestAST_ArrayEquality(t *testing.T) {
+	a := &ast.Array{
+		Expressions: []ast.Expression{
+			&ast.Attribute{Name: "a"},
+			&ast.Attribute{Name: "b"},
+		},
+	}
+
+	b := &ast.Array{
+		Expressions: []ast.Expression{
+			&ast.Attribute{Name: "a"},
+			&ast.Attribute{Name: "b"},
+		},
+	}
+
+	c := &ast.Array{
+		Expressions: []ast.Expression{
+			&ast.Attribute{Name: "b"},
+			&ast.Attribute{Name: "a"},
+		},
+	}
+
+	assert.True(t, a.Equal(a)) // should be equal to itself
+	assert.True(t, a.Equal(b)) // should be equal to another identical array
+	assert.False(t, a.Equal(c))
+}
+
+func TestAST_TupleEquality(t *testing.T) {
+	a := &ast.Tuple{
+		Members: []ast.Expression{
+			&ast.Attribute{Name: "a"},
+			&ast.Attribute{Name: "b"},
+		},
+	}
+
+	b := &ast.Tuple{
+		Members: []ast.Expression{
+			&ast.Attribute{Name: "a"},
+			&ast.Attribute{Name: "b"},
+		},
+	}
+
+	c := &ast.Tuple{
+		Members: []ast.Expression{
+			&ast.Attribute{Name: "b"},
+			&ast.Attribute{Name: "a"},
+		},
+	}
+
+	assert.True(t, a.Equal(a)) // should be equal to itself
+	assert.True(t, a.Equal(b)) // should be equal to another identical tuple
+	assert.False(t, a.Equal(c))
+}


### PR DESCRIPTION
Comparison for these nodes were only true if the length of the Expression was 1, or it was a list of the same expressions. 