### PR TITLE
chore(parservX): add test for function separator

### DIFF
--- a/parser/internal/parservX/parser_test.go
+++ b/parser/internal/parservX/parser_test.go
@@ -137,6 +137,8 @@ func TestErrors(t *testing.T) {
 	assertParseFailure(t, "def foo::bar($baz) { a, b }", "expected '=' following ()", 19, 19)
 	assertParseFailure(t, "def foo::bar(baz) = { a, b }", "expected parameter name", 13, 13)
 	assertParseFailure(t, "def foo::moo($woo) = $woo{ a, b }; def foo::bar($baz) = $woo{ a, b }", "param $woo referenced, but not provided", 56, 59)
+	assertParseFailure(t, "def foo::bar($baz) = $baz{ a, b } def", "expected ';' at the end of function definition", 34, 34)
+
 }
 
 func assertParseFailure(t *testing.T, src string, message string, start int, end int) {


### PR DESCRIPTION
Forgot to add a test in the other PR.