### PR TITLE
feat(parservX): add ast.Walk checking parent scope

### DIFF
--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -88,3 +88,130 @@ func TestAST_TupleEquality(t *testing.T) {
 	assert.True(t, a.Equal(b)) // should be equal to another identical tuple
 	assert.False(t, a.Equal(c))
 }
+
+// Note that ValidateParentAccess is exclusively used for custom defined functions,
+// where we don't allow reaching outside the function scope.
+func TestAST_ValidateParentAccess(t *testing.T) {
+	// This is a valid AST, as parent access is used correctly (within a filter)
+	// def foo::bar($baz) = $baz[]->{"foo": *[_type == ^.bar]};
+	valid_parentWithinFilter := &ast.Object{
+		Expressions: []ast.Expression{
+			&ast.BinaryOperator{
+				LHS: &ast.StringLiteral{
+					Value: "foo",
+				},
+				RHS: &ast.Filter{
+					LHS: &ast.Everything{},
+					Constraint: &ast.Constraint{
+						Expression: &ast.BinaryOperator{
+							LHS: &ast.Attribute{
+								Name: "_type",
+							},
+							RHS: &ast.DotOperator{
+								LHS: &ast.Parent{},
+								RHS: &ast.Attribute{
+									Name: "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// This is a valid AST, as parent access is used correctly (within a projection)
+	// def foo::bar($baz) = $baz[]->{"foo": *[_type == "bar"]{^.name}};
+	valid_parentWithinProjection := &ast.Object{
+		Expressions: []ast.Expression{
+			&ast.BinaryOperator{
+				LHS: &ast.StringLiteral{
+					Value: "foo",
+				},
+				RHS: &ast.Projection{
+					LHS: &ast.Filter{
+						LHS: &ast.Everything{},
+						Constraint: &ast.Constraint{
+							Expression: &ast.BinaryOperator{
+								LHS: &ast.Attribute{
+									Name: "_type",
+								},
+								RHS: &ast.StringLiteral{
+									Value: "bar",
+								},
+							},
+						},
+					},
+					Object: &ast.Object{
+						Expressions: []ast.Expression{
+							&ast.DotOperator{
+								LHS: &ast.Parent{},
+								RHS: &ast.Attribute{
+									Name: "name",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// This is a valid AST, as parent access is used correctly (within an order())
+	// def foo::bar($baz) = $baz[]->{"foo": *[_type == "person"] | order(^.foo)};
+	valid_parentWithinFunctionOrder := &ast.Object{
+		Expressions: []ast.Expression{
+			&ast.BinaryOperator{
+				LHS: &ast.StringLiteral{
+					Value: "foo",
+				},
+				RHS: &ast.FunctionPipe{
+					LHS: &ast.Filter{
+						LHS: &ast.Everything{},
+						Constraint: &ast.Constraint{
+							Expression: &ast.BinaryOperator{
+								LHS: &ast.Attribute{
+									Name: "_type",
+								},
+								RHS: &ast.StringLiteral{
+									Value: "person",
+								},
+							},
+						},
+					},
+					Func: &ast.FunctionCall{
+						Namespace: "global",
+						Name:      "order",
+						Arguments: []ast.Expression{
+							&ast.DotOperator{
+								LHS: &ast.Parent{},
+								RHS: &ast.Attribute{
+									Name: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// This is an invalid way of using parent in the AST
+	// def foo::bar($baz) = $baz[]->{ foo: ^.name};
+	invalid_parentReachesOutsideOfScope := &ast.Object{
+		Expressions: []ast.Expression{
+			&ast.DotOperator{
+				LHS: &ast.Parent{},
+				RHS: &ast.Attribute{
+					Name: "name",
+				},
+			},
+		},
+	}
+
+	assert.NoError(t, ast.ValidateParentAccess(valid_parentWithinFilter))
+	assert.NoError(t, ast.ValidateParentAccess(valid_parentWithinProjection))
+	assert.NoError(t, ast.ValidateParentAccess(valid_parentWithinFunctionOrder))
+
+	assert.Error(t, ast.ValidateParentAccess(invalid_parentReachesOutsideOfScope))
+}

--- a/ast/walk.go
+++ b/ast/walk.go
@@ -72,6 +72,112 @@ func Walk(expr Expression, visitor func(Expression) bool) bool {
 	panic(fmt.Sprintf("Unexpected AST expression of type %T: %[1]v", expr))
 }
 
+// WalkAndFindParentUsageInvalid is like Walk() but it returns an error if an invalid
+// parent usage is found.
+// This function is exclusively used to walk the body of a custom defined function.
+// The usage of a parent operator is *not* allowed in the body of a custom defined function
+// if it reaches out of that function's scope. It's valid within a filter or a projection, because
+// we create NewNestedScope for those.
+func WalkAndFindParentUsageInvalid(count int, expr Expression) (int, error) {
+	if expr == nil {
+		return count, nil
+	}
+	switch e := expr.(type) {
+	case *Parent:
+		count--
+		if count <= 0 {
+			return count, fmt.Errorf("Parent usage is invalid")
+		}
+		return count, nil
+	case *Everything, *This, *Ellipsis, *StringLiteral,
+		*FloatLiteral, *BooleanLiteral, *IntegerLiteral, *NullLiteral, *Attribute,
+		*ArrayTraversal, *Param, *FunctionParam:
+		return count, nil
+	case *Constraint:
+		return WalkAndFindParentUsageInvalid(count, e.Expression)
+	case *Subscript:
+		return WalkAndFindParentUsageInvalid(count, e.Value)
+	case *Range:
+		if c, err := WalkAndFindParentUsageInvalid(count, e.Start); err != nil {
+			return c, err
+		}
+		return WalkAndFindParentUsageInvalid(count, e.End)
+	case *BinaryOperator:
+		if c, err := WalkAndFindParentUsageInvalid(count, e.LHS); err != nil {
+			return c, err
+		}
+		return WalkAndFindParentUsageInvalid(count, e.RHS)
+	case *DotOperator:
+		// Chain the count between LHS and RHS sides of the dot operator.
+		c, err := WalkAndFindParentUsageInvalid(count, e.LHS)
+		if err != nil {
+			return c, err
+		}
+		return WalkAndFindParentUsageInvalid(c, e.RHS)
+	case *Group:
+		return WalkAndFindParentUsageInvalid(count, e.Expression)
+	case *PipeOperator:
+		if _, err := WalkAndFindParentUsageInvalid(count, e.LHS); err != nil {
+			return count, err
+		}
+		return WalkAndFindParentUsageInvalid(count, e.RHS)
+	case *PrefixOperator:
+		return WalkAndFindParentUsageInvalid(count, e.RHS)
+	case *PostfixOperator:
+		return WalkAndFindParentUsageInvalid(count, e.LHS)
+	case *Array:
+	case *Object:
+		for _, expr := range e.Expressions {
+			if c, err := WalkAndFindParentUsageInvalid(count, expr); err != nil {
+				return c, err
+			}
+		}
+		return count, nil
+	case *FunctionCall:
+		for _, arg := range e.Arguments {
+			if c, err := WalkAndFindParentUsageInvalid(count, arg); err != nil {
+				return c, err
+			}
+		}
+		return count, nil
+	case *FunctionPipe:
+		if c, err := WalkAndFindParentUsageInvalid(count, e.LHS); err != nil {
+			return c, err
+		}
+		return WalkAndFindParentUsageInvalid(count, e.Func)
+	case *Filter:
+		if c, err := WalkAndFindParentUsageInvalid(count, e.LHS); err != nil {
+			return c, err
+		}
+
+		return WalkAndFindParentUsageInvalid(count+1, e.Constraint)
+	case *Slice:
+		if c, err := WalkAndFindParentUsageInvalid(count, e.LHS); err != nil {
+			return c, err
+		}
+		return WalkAndFindParentUsageInvalid(count, e.Range)
+	case *Element:
+		if c, err := WalkAndFindParentUsageInvalid(count, e.LHS); err != nil {
+			return c, err
+		}
+		return WalkAndFindParentUsageInvalid(count, e.Idx)
+	case *Projection:
+		if c, err := WalkAndFindParentUsageInvalid(count, e.LHS); err != nil {
+			return c, err
+		}
+		return WalkAndFindParentUsageInvalid(count+1, e.Object)
+	case *Tuple:
+		for _, member := range e.Members {
+			if c, err := WalkAndFindParentUsageInvalid(count, member); err != nil {
+				return c, err
+			}
+		}
+		return count, nil
+	}
+
+	panic(fmt.Sprintf("Unexpected AST expression of type %T: %[1]v", expr))
+}
+
 func walkExprs(visitor func(Expression) bool, exprs ...Expression) bool {
 	for _, expr := range exprs {
 		if !Walk(expr, visitor) {

--- a/parser/internal/parservX/parser_test.go
+++ b/parser/internal/parservX/parser_test.go
@@ -219,7 +219,8 @@ func ASTTest(
 	// append to a slice and sort since maps are not ordered
 	for _, fn := range test.Functions {
 		// Make sure we can walk the function body
-		assert.True(t, ast.Walk(fn.Body, func(expr ast.Expression) bool { return true }))
+		_, err = ast.WalkAndFindParentUsageInvalid(0, fn.Body)
+		require.NoError(t, err)
 
 		result.Functions = append(result.Functions, fn)
 	}

--- a/parser/internal/parservX/parser_test.go
+++ b/parser/internal/parservX/parser_test.go
@@ -219,7 +219,7 @@ func ASTTest(
 	// append to a slice and sort since maps are not ordered
 	for _, fn := range test.Functions {
 		// Make sure we can walk the function body
-		_, err = ast.WalkAndFindParentUsageInvalid(0, fn.Body)
+		err = ast.ValidateParentAccess(fn.Body)
 		require.NoError(t, err)
 
 		result.Functions = append(result.Functions, fn)


### PR DESCRIPTION
We need a variation of the ast.Walk function which keeps track of usage of parent scope sign ^ vs. the usage of filters or projections.
This is exclusively used to walk the body of custom defined functions, as we don't allow the usage of parent scope which reaches out of the function.