### PR TITLE
refactor: move ParseError struct into the ast package

### DIFF
--- a/ast/error.go
+++ b/ast/error.go
@@ -1,0 +1,23 @@
+package ast
+
+import "fmt"
+
+// ParseError represents an error during parsing
+type ParseError struct {
+	msg string
+	pos Position
+}
+
+func NewParseError(msg string, pos Position) *ParseError {
+	return &ParseError{msg: msg, pos: pos}
+}
+
+func (e *ParseError) Pos() Position   { return e.pos }
+func (e *ParseError) Message() string { return e.msg }
+
+func (e *ParseError) Error() string {
+	if e.pos.Start == e.pos.End {
+		return fmt.Sprintf("parse error at position %d: %s", e.pos.End, e.msg)
+	}
+	return fmt.Sprintf("parse error at positions %d..%d: %s", e.pos.Start, e.pos.End, e.msg)
+}

--- a/parser/internal/parservX/parser.go
+++ b/parser/internal/parservX/parser.go
@@ -9,22 +9,6 @@ import (
 	"github.com/sanity-io/go-groq/tokenizer"
 )
 
-// parseError represents an error during parsing
-type parseError struct {
-	msg string
-	pos ast.Position
-}
-
-func (e *parseError) Pos() ast.Position { return e.pos }
-func (e *parseError) Message() string   { return e.msg }
-
-func (e *parseError) Error() string {
-	if e.pos.Start == e.pos.End {
-		return fmt.Sprintf("parse error at position %d: %s", e.pos.End, e.msg)
-	}
-	return fmt.Sprintf("parse error at positions %d..%d: %s", e.pos.Start, e.pos.End, e.msg)
-}
-
 type Option func(*parser)
 
 func WithParams(p groq.Params) Option {
@@ -127,17 +111,17 @@ func (p *parser) dereferenceParam(name string, pos int) (ast.Expression, error) 
 	value, exists := p.params[name]
 
 	if !exists {
-		return nil, &parseError{
-			msg: fmt.Sprintf("param $%s referenced, but not provided", name),
-			pos: p.makeTokenPos(pos, name),
-		}
+		return nil, ast.NewParseError(
+			fmt.Sprintf("param $%s referenced, but not provided", name),
+			p.makeTokenPos(pos, name))
+
 	}
 	expr, err := ast.LiteralFromInterface(value, p.makeTokenPos(pos, name))
 	if err != nil {
-		return nil, &parseError{
-			msg: fmt.Sprintf("error while accessing value of $%s: %s", name, err.Error()),
-			pos: p.makeTokenPos(pos, name),
-		}
+		return nil, ast.NewParseError(
+			fmt.Sprintf("error while accessing value of $%s: %s", name, err.Error()),
+			p.makeTokenPos(pos, name))
+
 	}
 	return expr, nil
 }
@@ -239,10 +223,10 @@ func (p *parser) parseAtom(immediateLHS bool) (ast.Expression, error) {
 			if expr == nil {
 				// This is actually impossible to trigger barring an error in the parser itself.
 				// Turn into a panic?
-				return nil, &parseError{
-					msg: "expected constraint, subscript dereference or range",
-					pos: p.makeTokenPos(pos, lit),
-				}
+				return nil, ast.NewParseError(
+					"expected constraint, subscript dereference or range",
+					p.makeTokenPos(pos, lit))
+
 			}
 		} else {
 			// This is a square-bracketed thing with no immediate LHS, so must be array
@@ -253,10 +237,10 @@ func (p *parser) parseAtom(immediateLHS bool) (ast.Expression, error) {
 			if expr == nil {
 				// This is actually impossible to trigger barring an error in the parser itself.
 				// Turn into a panic?
-				return nil, &parseError{
-					msg: "expected array expression",
-					pos: p.makeTokenPos(pos, lit),
-				}
+				return nil, ast.NewParseError(
+					"expected array expression",
+					p.makeTokenPos(pos, lit))
+
 			}
 		}
 		return expr, nil
@@ -269,10 +253,10 @@ func (p *parser) parseAtom(immediateLHS bool) (ast.Expression, error) {
 		if expr == nil {
 			// This is actually impossible to trigger barring an error in the parser itself.
 			// Turn into a panic?
-			return nil, &parseError{
-				msg: "expected object expression",
-				pos: p.makeTokenPos(pos, lit),
-			}
+			return nil, ast.NewParseError(
+				"expected object expression",
+				p.makeTokenPos(pos, lit))
+
 		}
 		return expr, nil
 	}
@@ -308,10 +292,10 @@ func (p *parser) parseParenthesisExpr(pos int, lit string) (ast.Expression, erro
 	}
 
 	if tok != ast.ParenRight {
-		return nil, &parseError{
-			msg: "expected ')' following parenthesized expression",
-			pos: p.makeRangePos(pos, tokPos),
-		}
+		return nil, ast.NewParseError(
+			"expected ')' following parenthesized expression",
+			p.makeRangePos(pos, tokPos))
+
 	}
 
 	if len(tupleMembers) > 0 {
@@ -383,10 +367,10 @@ func (p *parser) parseGeneralExpression(minPrecedence int, immediateLHS bool, ma
 			seen = fmt.Sprintf("token %q", aLit)
 		}
 
-		return nil, &parseError{
-			msg: fmt.Sprintf("unexpected %s, expected expression", seen),
-			pos: p.makeTokenPos(pos, aLit),
-		}
+		return nil, ast.NewParseError(
+			fmt.Sprintf("unexpected %s, expected expression", seen),
+			p.makeTokenPos(pos, aLit))
+
 	}
 
 	// At this point, expr is the first value in a potential chain of values stringed together with
@@ -493,10 +477,10 @@ Loop:
 		// Infix operator
 		if !isInfixOperator(operator) {
 			// Impossible to trigger barring a bug in the parser. Turn into panic?
-			return nil, &parseError{
-				msg: fmt.Sprintf("expected infix operator, but saw %q", operator.Literal()),
-				pos: p.makeTokenPos(pos, lit),
-			}
+			return nil, ast.NewParseError(
+				fmt.Sprintf("expected infix operator, but saw %q", operator.Literal()),
+				p.makeTokenPos(pos, lit))
+
 		}
 
 		rhsHasImmediateLHS := operator == ast.Pipe || operator == ast.Dot
@@ -516,10 +500,8 @@ Loop:
 			}
 		}
 		if rhs == nil {
-			return nil, &parseError{
-				pos: p.makeTokenPos(pos, lit),
-				msg: "expected expressions following operator",
-			}
+			return nil, ast.NewParseError("expected expressions following operator", p.makeTokenPos(pos, lit))
+
 		}
 
 		switch operator {
@@ -528,17 +510,17 @@ Loop:
 			case *ast.Parent:
 				// attribute.^ is not allowed but ^.^, ^.^.^ etc. is allowed
 				if !isParentDereferencing(expr) {
-					return nil, &parseError{
-						pos: rhs.GetPos(),
-						msg: "^ is not allowed here",
-					}
+					return nil, ast.NewParseError(
+
+						"^ is not allowed here", rhs.GetPos())
+
 				}
 			case *ast.This:
 				// attribute.@ is not allowed
-				return nil, &parseError{
-					pos: rhs.GetPos(),
-					msg: "@ is not allowed here",
-				}
+				return nil, ast.NewParseError(
+
+					"@ is not allowed here", rhs.GetPos())
+
 			}
 			expr = &ast.DotOperator{
 				Pos: p.makeTokenPos(pos, lit),
@@ -560,10 +542,10 @@ Loop:
 					Func: rhs,
 				}
 			default:
-				return nil, &parseError{
-					pos: rhs.GetPos(),
-					msg: "object or function expected",
-				}
+				return nil, ast.NewParseError(
+
+					"object or function expected", rhs.GetPos())
+
 			}
 		default:
 			binOp := &ast.BinaryOperator{
@@ -599,10 +581,10 @@ func (p *parser) parseChainedBracketedExpression() (ast.Expression, error) {
 	rangeEnd := posEnd + len(litEnd)
 
 	if tok != ast.BracketRight {
-		return nil, &parseError{
-			msg: "expected ']' following expression",
-			pos: p.makeRangePos(posStart, rangeEnd),
-		}
+		return nil, ast.NewParseError(
+			"expected ']' following expression",
+			p.makeRangePos(posStart, rangeEnd))
+
 	}
 
 	if expr == nil {
@@ -620,10 +602,10 @@ func (p *parser) parseChainedBracketedExpression() (ast.Expression, error) {
 		}, nil
 	case *ast.Range:
 		if !ast.IsSubscriptExpression(t) {
-			return nil, &parseError{
-				msg: "subscript ranges must have integer endpoints",
-				pos: p.makeRangePos(posStart, rangeEnd),
-			}
+			return nil, ast.NewParseError(
+				"subscript ranges must have integer endpoints",
+				p.makeRangePos(posStart, rangeEnd))
+
 		}
 		return &ast.Subscript{
 			Pos:   p.makeRangePos(posStart, rangeEnd),
@@ -661,10 +643,10 @@ func (p *parser) parseArrayExpression() (ast.Expression, error) {
 	rangeEnd := posEnd + len(litEnd)
 
 	if tok != ast.BracketRight {
-		return nil, &parseError{
-			msg: "expected ']' following array body",
-			pos: p.makeRangePos(posStart, rangeEnd),
-		}
+		return nil, ast.NewParseError(
+			"expected ']' following array body",
+			p.makeRangePos(posStart, rangeEnd))
+
 	}
 	return &ast.Array{
 		Pos:         p.makeRangePos(posStart, rangeEnd),
@@ -686,10 +668,10 @@ func (p *parser) parseObjectExpression() (ast.Expression, error) {
 	rangeEnd := posEnd + len(litEnd)
 
 	if tok != ast.BraceRight {
-		return nil, &parseError{
-			msg: "expected '}' following object body",
-			pos: p.makeRangePos(posStart, rangeEnd),
-		}
+		return nil, ast.NewParseError(
+			"expected '}' following object body",
+			p.makeRangePos(posStart, rangeEnd))
+
 	}
 	return &ast.Object{
 		Pos:         p.makeRangePos(posStart, rangeEnd),
@@ -705,19 +687,19 @@ func (p *parser) parseFunctionExpression(nameToken ast.Token, name string, nameP
 	switch tok {
 	case ast.DoubleColon:
 		if nameToken != ast.Name {
-			return nil, &parseError{
-				msg: fmt.Sprintf("expected valid namespace identifier before '%s'", ast.DoubleColon.String()),
-				pos: p.makeTokenPos(pos, lit),
-			}
+			return nil, ast.NewParseError(
+				fmt.Sprintf("expected valid namespace identifier before '%s'", ast.DoubleColon.String()),
+				p.makeTokenPos(pos, lit))
+
 		}
 
 		// It should be a function call after a double colon (namespace).
 		fTok, fLit, fPos := p.scanIgnoreWhitespace()
 		if fTok != ast.Name {
-			return nil, &parseError{
-				msg: "expected a function following namespace expression",
-				pos: p.makeTokenPos(fPos, fLit),
-			}
+			return nil, ast.NewParseError(
+				"expected a function following namespace expression",
+				p.makeTokenPos(fPos, fLit))
+
 		}
 
 		function, err := p.parseFunctionExpression(ast.DoubleColon, fLit, fPos)
@@ -725,10 +707,10 @@ func (p *parser) parseFunctionExpression(nameToken ast.Token, name string, nameP
 			return nil, err
 		}
 		if function == nil {
-			return nil, &parseError{
-				msg: "expected a function following namespace expression",
-				pos: p.makeTokenPos(fPos, fLit),
-			}
+			return nil, ast.NewParseError(
+				"expected a function following namespace expression",
+				p.makeTokenPos(fPos, fLit))
+
 		}
 		function.Namespace = name    // Assign namespace to function call.
 		function.Pos.Start = namePos // Reset position to start of namespace.
@@ -761,10 +743,10 @@ func (p *parser) parseFunctionExpression(nameToken ast.Token, name string, nameP
 		tok, litEnd, posEnd := p.scanIgnoreWhitespace()
 		rangeEnd := posEnd + len(litEnd)
 		if tok != ast.ParenRight {
-			return nil, &parseError{
-				msg: "expected ')' following function arguments",
-				pos: p.makeRangePos(pos, rangeEnd),
-			}
+			return nil, ast.NewParseError(
+				"expected ')' following function arguments",
+				p.makeRangePos(pos, rangeEnd))
+
 		}
 	default:
 		p.unscan()
@@ -814,10 +796,10 @@ func (p *parser) parseList() ([]ast.Expression, error) {
 func (p *parser) parse() (ast.Expression, error) {
 	token, _, _ := p.scanIgnoreWhitespace()
 	if token == ast.EOF {
-		return nil, &parseError{
-			msg: "no query",
-			pos: p.makeSpotPos(0),
-		}
+		return nil, ast.NewParseError(
+			"no query",
+			p.makeSpotPos(0))
+
 	}
 	p.unscan()
 
@@ -834,10 +816,10 @@ func (p *parser) parse() (ast.Expression, error) {
 
 	token, _, pos := p.scanIgnoreWhitespace()
 	if token != ast.EOF {
-		return nil, &parseError{
-			msg: "unable to parse entire expression",
-			pos: p.makeSpotPos(pos),
-		}
+		return nil, ast.NewParseError(
+			"unable to parse entire expression",
+			p.makeSpotPos(pos))
+
 	}
 	return result, nil
 }
@@ -885,10 +867,10 @@ func (p *parser) parseFunctionDefinition() (*ast.FunctionDefinition, error) {
 
 	tok, lit, pos := p.scanIgnoreWhitespace()
 	if tok != ast.ParenLeft {
-		return nil, &parseError{
-			msg: "expected '(' following function name",
-			pos: p.makeSpotPos(pos),
-		}
+		return nil, ast.NewParseError(
+			"expected '(' following function name",
+			p.makeSpotPos(pos))
+
 	}
 
 	params, err := p.parseFunctionParameters()
@@ -900,18 +882,18 @@ func (p *parser) parseFunctionDefinition() (*ast.FunctionDefinition, error) {
 
 	tok, _, pos = p.scanIgnoreWhitespace()
 	if tok != ast.ParenRight {
-		return nil, &parseError{
-			msg: "expected ')' following function arguments",
-			pos: p.makeSpotPos(pos),
-		}
+		return nil, ast.NewParseError(
+			"expected ')' following function arguments",
+			p.makeSpotPos(pos))
+
 	}
 
 	tok, lit, pos = p.scanIgnoreWhitespace()
 	if tok != ast.EqualSign {
-		return nil, &parseError{
-			msg: "expected '=' following ()",
-			pos: p.makeSpotPos(pos),
-		}
+		return nil, ast.NewParseError(
+			"expected '=' following ()",
+			p.makeSpotPos(pos))
+
 	}
 
 	body, err := p.parseFunctionBody()
@@ -921,10 +903,10 @@ func (p *parser) parseFunctionDefinition() (*ast.FunctionDefinition, error) {
 
 	tok, _, pos = p.scanIgnoreWhitespace()
 	if tok != ast.Semicolon {
-		return nil, &parseError{
-			msg: "expected ';' at the end of function definition",
-			pos: p.makeSpotPos(pos),
-		}
+		return nil, ast.NewParseError(
+			"expected ';' at the end of function definition",
+			p.makeSpotPos(pos))
+
 	}
 	p.functionParameters = nil
 
@@ -940,27 +922,27 @@ func (p *parser) parseFunctionDefinition() (*ast.FunctionDefinition, error) {
 func (p *parser) parseFunctionName() (string, string, error) {
 	tok, lit, pos := p.scanIgnoreWhitespace()
 	if tok != ast.Name {
-		return "", "", &parseError{
-			msg: "expected function namespace",
-			pos: p.makeSpotPos(pos),
-		}
+		return "", "", ast.NewParseError(
+			"expected function namespace",
+			p.makeSpotPos(pos))
+
 	}
 	functionNamespace := lit
 
 	tok, lit, pos = p.scanIgnoreWhitespace()
 	if tok != ast.DoubleColon {
-		return "", "", &parseError{
-			msg: "expected '::' followed by a function name",
-			pos: p.makeSpotPos(pos),
-		}
+		return "", "", ast.NewParseError(
+			"expected '::' followed by a function name",
+			p.makeSpotPos(pos))
+
 	}
 
 	tok, lit, pos = p.scanIgnoreWhitespace()
 	if tok != ast.Name {
-		return "", "", &parseError{
-			msg: "expected a function name",
-			pos: p.makeSpotPos(pos),
-		}
+		return "", "", ast.NewParseError(
+			"expected a function name",
+			p.makeSpotPos(pos))
+
 	}
 	functionName := lit
 
@@ -973,10 +955,10 @@ func (p *parser) parseFunctionParameters() ([]*ast.FunctionParamDefinition, erro
 	// We only allow 1 argument at the moment
 	tok, lit, pos := p.scanIgnoreWhitespace()
 	if tok != ast.Name || lit[0] != '$' {
-		return nil, &parseError{
-			msg: "expected parameter name",
-			pos: p.makeSpotPos(pos),
-		}
+		return nil, ast.NewParseError(
+			"expected parameter name",
+			p.makeSpotPos(pos))
+
 	}
 	param := &ast.FunctionParamDefinition{
 		// Since we only allow 1 parameter per function at the moment, Index is always 0.


### PR DESCRIPTION
This accomplishes two things:

- We get to reuse the same struct for parse errors across our parsers
- It's possible now to return ParseError from the `ast` package as well. See #31 for where we want to validate after the initial parse.